### PR TITLE
fix a broadcast exploit in AnimationPacket

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3168,7 +3168,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     }
 
                     AnimatePacket animatePacket = (AnimatePacket) packet;
-                    AnimatePacket.Action animation = animationEvent.getAnimationType();
+                    AnimatePacket.Action animation = animatePacket.action;
                     
                     // prevent client send illegal packet to server and broadcast to other client and make other client crash
                     if(animation == null // illegal action id
@@ -3183,6 +3183,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     if (animationEvent.isCancelled()) {
                         break;
                     }
+                    animation = animationEvent.getAnimationType();
 
                     switch (animation) {
                         case ROW_RIGHT:

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3169,12 +3169,20 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                     AnimatePacket animatePacket = (AnimatePacket) packet;
                     PlayerAnimationEvent animationEvent = new PlayerAnimationEvent(this, animatePacket);
+                    AnimatePacket.Action animation = animationEvent.getAnimationType();
+                    
+                    // prevent client send illegal packet to server and broadcast to other client and make other client crash
+                    if(animation == null // illegal action id
+                            || animation == AnimatePacket.Action.WAKE_UP // these actions are only for server to client
+                            || animation == AnimatePacket.Action.CRITICAL_HIT
+                            || animation == AnimatePacket.Action.MAGIC_CRITICAL_HIT) {
+                        break; // maybe we should cancel the event here? but if client send too many packets, server will lag
+                    }
+                    
                     this.server.getPluginManager().callEvent(animationEvent);
                     if (animationEvent.isCancelled()) {
                         break;
                     }
-
-                    AnimatePacket.Action animation = animationEvent.getAnimationType();
 
                     switch (animation) {
                         case ROW_RIGHT:

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3168,7 +3168,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     }
 
                     AnimatePacket animatePacket = (AnimatePacket) packet;
-                    PlayerAnimationEvent animationEvent = new PlayerAnimationEvent(this, animatePacket);
                     AnimatePacket.Action animation = animationEvent.getAnimationType();
                     
                     // prevent client send illegal packet to server and broadcast to other client and make other client crash
@@ -3176,9 +3175,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             || animation == AnimatePacket.Action.WAKE_UP // these actions are only for server to client
                             || animation == AnimatePacket.Action.CRITICAL_HIT
                             || animation == AnimatePacket.Action.MAGIC_CRITICAL_HIT) {
-                        break; // maybe we should cancel the event here? but if client send too many packets, server will lag
+                        break;
                     }
                     
+                    PlayerAnimationEvent animationEvent = new PlayerAnimationEvent(this, animatePacket);
                     this.server.getPluginManager().callEvent(animationEvent);
                     if (animationEvent.isCancelled()) {
                         break;


### PR DESCRIPTION
A "hacked client" can send AnimationPacket with illegal Action, like CRITICAL_HIT.
If the illegal client send too many these packets(like 1000 pps?), viewers' client will drop fps or crash